### PR TITLE
devmem: fix double plus offset

### DIFF
--- a/devmem.py
+++ b/devmem.py
@@ -162,7 +162,8 @@ class DevMem:
         mem = self.mem
 
         # Compensate for the base_address not being what the user requested
-        offset += self.base_addr_offset
+        # fix double plus offset
+        #offset += self.base_addr_offset
 
         # Check that the operation is going write to an aligned location
         if (offset & ~self.mask): raise AssertionError


### PR DESCRIPTION
fix double plus offset:
if base_addr_offset is not equal zero,  seek in write will be error.
